### PR TITLE
Revert "fix swagger spec"

### DIFF
--- a/src/main/java/io/openshift/booster/swagger/SwaggerConfiguration.java
+++ b/src/main/java/io/openshift/booster/swagger/SwaggerConfiguration.java
@@ -1,19 +1,12 @@
 package io.openshift.booster.swagger;
 
 import com.google.common.base.Predicates;
-import com.google.common.collect.Lists;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.bind.annotation.RequestMethod;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.builders.ResponseMessageBuilder;
-import springfox.documentation.schema.ModelRef;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-
-import java.util.Arrays;
-import java.util.HashSet;
 
 /**
  * @author Florent Benoit
@@ -21,29 +14,16 @@ import java.util.HashSet;
 @Configuration
 public class SwaggerConfiguration {
 
-    @Bean
-    public Docket docket() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .protocols(new HashSet<>(Lists.newArrayList("http", "https", "ws", "wss")))
-                .globalResponseMessage(RequestMethod.PUT,
-                        Lists.newArrayList(
-                                new ResponseMessageBuilder().code(201).message("Created")
-                                        .responseModel(new ModelRef("Fruit")).build()
-                        )
-                )
-                .useDefaultResponseMessages(false)
-                .globalResponseMessage(RequestMethod.DELETE,
-                        Lists.newArrayList(
-                                new ResponseMessageBuilder().code(204).message("No Content")
-                                        .responseModel(new ModelRef("")).build()
-                        )
-                )
-                .select()
-                .apis(RequestHandlerSelectors.withMethodAnnotation(ApiOperation.class))
-                .apis(Predicates.not(RequestHandlerSelectors.basePackage("org.springframework.boot")))
-                .apis(Predicates.not(RequestHandlerSelectors.basePackage("org.springframework.cloud")))
-                .apis(Predicates.not(RequestHandlerSelectors.basePackage("org.springframework.data.rest.webmvc")))
-                .build();
-    }
+        @Bean
+        public Docket docket() {
+            return new Docket(DocumentationType.SWAGGER_2).select()
+                    .apis(RequestHandlerSelectors.withMethodAnnotation(ApiOperation.class))
+                    .apis(Predicates.not(RequestHandlerSelectors.basePackage("org.springframework.boot")))
+                    .apis(Predicates.not(RequestHandlerSelectors.basePackage("org.springframework.cloud")))
+                    .apis(Predicates.not(RequestHandlerSelectors.basePackage("org.springframework.data.rest.webmvc")))
+                    .build();
+        }
+
+
 
 }


### PR DESCRIPTION
This reverts commit 3fbf65bfda45af0aa348c66aede720cf637929bb.

The referenced commit made changes to the Swagger spec of the app
that resulted in its import into fuse no longer working. However,
in the installer, even though the image tag references a commit
after this commit, none of these changes are included.

My guess is that a manual build of the image was done using an old
commit but given a later commit tag. So the changes in the reverted
commit were never included in Integreatly until yesterday.